### PR TITLE
Add a diagnostic if the manifest can't be found

### DIFF
--- a/stile/data_source_stile_manifest.go
+++ b/stile/data_source_stile_manifest.go
@@ -135,7 +135,7 @@ func getBuildkiteArtifact(artifactName string, buildNumber string, pipeline stri
 	diags = append(diags, diag.Diagnostic{
 		Severity: diag.Error,
 		Summary: "Could not find manifest",
-		Detail: fmt.Sprintf("Could not find manifest %s for build number %s", artifactName, buildNumber),
+		Detail: fmt.Sprintf("Could not find Stile Manifest artefact named %s for build number %s in Buildkite", artifactName, buildNumber),
 	})
 	log.Printf("Could not find manifest %s for build number %s", artifactName, buildNumber)
 

--- a/stile/data_source_stile_manifest.go
+++ b/stile/data_source_stile_manifest.go
@@ -135,7 +135,7 @@ func getBuildkiteArtifact(artifactName string, buildNumber string, pipeline stri
 	diags = append(diags, diag.Diagnostic{
 		Severity: diag.Error,
 		Summary: "Could not find manifest",
-		Detail: fmt.Sprintf("Could not find Stile Manifest artefact named %s for build number %s in Buildkite", artifactName, buildNumber),
+		Detail: fmt.Sprintf("Could not find Stile Manifest artifact named %s for build number %s in Buildkite", artifactName, buildNumber),
 	})
 	log.Printf("Could not find manifest %s for build number %s", artifactName, buildNumber)
 

--- a/stile/data_source_stile_manifest.go
+++ b/stile/data_source_stile_manifest.go
@@ -132,6 +132,13 @@ func getBuildkiteArtifact(artifactName string, buildNumber string, pipeline stri
 		}
 	}
 
+	diags = append(diags, diag.Diagnostic{
+		Severity: diag.Error,
+		Summary: "Could not find manifest",
+		Detail: fmt.Sprintf("Could not find manifest %s for build number %s", artifactName, buildNumber),
+	})
+	log.Printf("Could not find manifest %s for build number %s", artifactName, buildNumber)
+
 	return nil, diags
 }
 


### PR DESCRIPTION
Previously if you typo'd the manifest name Terraform would blow up
because we hadn't appended anything to `diag` so it was `nil` and we
were returning `nil` for the the artifact. This ended up in the
provider plugin segfaulting.

Now we get a diagnostic error message:

```
Error: Could not find manifest

Could not find manifest does_not_exist.json for build number 470011
```
