### PR TITLE
Scroll through paginated buildkite artifacts to find manifest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,9 @@ install: build
 	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 
-test: 
-	go test -i $(TEST) || exit 1                                                   
-	echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4                    
+test:
+	go test -i $(TEST) || exit 1
+	echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 
-testacc: 
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m   
+testacc:
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m


### PR DESCRIPTION
The buildkite API paginates the list artifacts for job endpoint so when
there are jobs that we output a lot of artifacts for, the manifest we're
searching for may not be included in the first page. This adds scrolling
through the pages until we either find the manifest or run out of pages.

Originally I had wrapped up getting _all_ the artifacts then just iterating
through those. It's a little less complicated but didn't make full use of
pagination. Now we only scroll until the manifest is found and return
early.

w=1 is your friend here: https://github.com/StileEducation/terraform-provider-stile/pull/4/files?w=1