### PR TITLE
Allow falling back to a hard coded manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ override.tf.json
 .terraformrc
 terraform.rc
 terraform
+
+# Ignore the binary created by `make build`
+terraform-provider-stile

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ NAMESPACE=edu
 NAME=stile
 BINARY=terraform-provider-${NAME}
 VERSION=0.2
-OS_ARCH=darwin_amd64
+OS_ARCH=$(shell echo "$$(uname -s)_$$(uname -m)" | awk '{ print tolower($$0) }')
 
 default: install
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is an internal tool used by Stile Education for fetching "manifests" an int
 Run the following command to build the provider
 
 ```shell
-go build -o terraform-provider-stile-manifest
+make build
 ```
 
 ## Test sample configuration

--- a/examples/stile_manifest/main.tf
+++ b/examples/stile_manifest/main.tf
@@ -1,15 +1,34 @@
 terraform {
   required_providers {
     stile = {
-      versions = ["0.2"]
+      version = "0.2"
       source = "hashicorp.com/edu/stile"
     }
   }
 }
 
 data "stile_manifest" "all" {
-  bfp_build_number = 470011
-  manifest_name = "untested-excel-exporter-manifest.json"
+  bfp_build_number = 926993
+  manifest_name = "untested-prober-service-manifest.json"
+  fallback_manifest = jsonencode({
+    "name": "926993",
+    "commits": {
+      "git@github.com:StileEducation/dev-environment.git": "a commit"
+    },
+    "service_versions": {
+      "stile-prober": "stile-prober",
+      "stile-prometheus-node-exporter": "stile-prometheus-node-exporter",
+      "prober-service": "prober-service",
+      "stile-consul": "stile-consul",
+      "stile-container-monitor": "stile-container-monitor",
+      "registrator-docker-image": "registrator-docker-image"
+    },
+    "amis": {
+      "base-ami": "base-iamge",
+      "base-ami:ap-southeast-2": "base-ami:ap-southeast-2",
+      "base-ami:us-west-2": "base-ami:us-west-2"
+    }
+  })
 }
 
 # Returns all coffees
@@ -17,6 +36,6 @@ output "all" {
   value = data.stile_manifest.all
 }
 
-output "excel_exporter_image" {
-  value = data.stile_manifest.all.service_versions["stile-excel-exporter-docker-image"]
+output "image" {
+  value = data.stile_manifest.all.service_versions["stile-prober"]
 }

--- a/stile/data_source_stile_manifest.go
+++ b/stile/data_source_stile_manifest.go
@@ -43,7 +43,7 @@ func dataStileManifest() *schema.Resource {
 				Computed: false,
 			},
 			"fallback_manifest": &schema.Schema{
-				Type: schema.TypeString,
+				Type:     schema.TypeString,
 				Optional: true,
 				Required: false,
 				Computed: false,
@@ -69,7 +69,7 @@ func dataStileManifest() *schema.Resource {
 			// the terraform would say there is a diff when we don't
 			// want them to.
 			"used_fallback_manifest": &schema.Schema{
-				Type: schema.TypeBool,
+				Type:     schema.TypeBool,
 				Computed: true,
 			},
 		},
@@ -106,7 +106,7 @@ func getBuildkiteArtifact(apiToken string, artifactName string, buildNumber stri
 			log.Printf("list artifacts failed: %s", err)
 			return nil, diagnosticError{
 				summary: fmt.Sprintf("Unable to list buildkite artifacts for build %s in pipeline %s/%s", buildNumber, org, pipeline),
-				detail:  fmt.Sprintf(
+				detail: fmt.Sprintf(
 					"This can mean the artifact does not exist or your Buildkite API token has insufficient permission to access it: %v",
 					err,
 				),
@@ -236,7 +236,7 @@ func dataStileManifestRead(ctx context.Context, d *schema.ResourceData, m interf
 				// If we haven't disabled fallback, just warn that
 				// we're falling back.
 				diags = append(diags, diag.Diagnostic{
-					Severity:      diag.Warning,
+					Severity: diag.Warning,
 					Summary:  fmt.Sprintf("Manifest %s not found for build %s in %s/%s, using fallback", manifestName, bfpBuildNumber, org, pipeline),
 					Detail:   "This may be beause the build failed or it is on a branch that does not build the manifest. You can use fallback_manifest to specify a map of the manifest that should be used if the expected one does not exist. However, a fallback was specifie.",
 				})


### PR DESCRIPTION
We still need to be able to do deploys if some manifests aren't
created, they're just there to optimise the deployment process. This
allows specifying a JSON document to using if the manifest is not
found (different from there being some kind of error attempting to get
the manifest). I've added an env var, `STILE_MANIFEST_NO_FALLBACK`, to
prevent the fallback in cases e.g. CD where we want to catch the
manifests not existing.

I've also updated the `Makefile` so that `make build` works on ARM
(e.g. M1 macs).
