### PR TITLE
Return diagnostics for the manifest not being found

### DIFF
--- a/stile/data_source_stile_manifest.go
+++ b/stile/data_source_stile_manifest.go
@@ -254,6 +254,7 @@ func dataStileManifestRead(ctx context.Context, d *schema.ResourceData, m interf
 				Summary:  fmt.Sprintf("Manifest %s not found for build %s in %s/%s", manifestName, bfpBuildNumber, org, pipeline),
 				Detail:   "This may be beause the build failed or it is on a branch that does not build the manifest. You can use fallback_manifest to specify a map of the manifest that should be used if the expected one does not exist.",
 			})
+			return diags
 		}
 	}
 


### PR DESCRIPTION
If the manifest doesn\'t exist then `artifact` is `nil`, leading to a segfault.'
Now we give a nice error message. We should really have some tests for this thing...
