### PR TITLE
Give a better error message when the specified architecture is missing from the manifest

### DIFF
--- a/stile/data_source_stile_manifest.go
+++ b/stile/data_source_stile_manifest.go
@@ -180,7 +180,7 @@ func dataStileManifestRead(ctx context.Context, d *schema.ResourceData, m interf
 
 	apiToken, present := os.LookupEnv("BUILDKITE_READ_API_TOKEN")
 
-	if present == false {
+	if !present {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to find BUILDKITE_READ_API_TOKEN environment variable.",

--- a/stile/data_source_stile_manifest.go
+++ b/stile/data_source_stile_manifest.go
@@ -252,7 +252,7 @@ func dataStileManifestRead(ctx context.Context, d *schema.ResourceData, m interf
 					diags = append(diags, diag.Diagnostic{
 						Severity: diag.Error,
 						Summary:  fmt.Sprintf("Manifest %s not found for build %s in %s/%s", manifestName, bfpBuildNumber, org, pipeline),
-						Detail:   "This may be beause the build failed or it is on a branch that does not build the manifest. You can use fallback_manifest to specify a map of the manifest that should be used if the expected one does not exist. A fallback was specified via fallback_manifest but fallback was disabled via the STILE_MANIFEST_NO_FALLBACK environment variable.",
+						Detail:   "This may be because the build failed or it is on a branch that does not build the manifest. You can use fallback_manifest to specify a map of the manifest that should be used if the expected one does not exist. A fallback was specified via fallback_manifest but fallback was disabled via the STILE_MANIFEST_NO_FALLBACK environment variable.",
 					})
 					return diags
 				}
@@ -261,7 +261,7 @@ func dataStileManifestRead(ctx context.Context, d *schema.ResourceData, m interf
 				diags = append(diags, diag.Diagnostic{
 					Severity: diag.Warning,
 					Summary:  fmt.Sprintf("Manifest %s not found for build %s in %s/%s, using fallback", manifestName, bfpBuildNumber, org, pipeline),
-					Detail:   "This may be beause the build failed or it is on a branch that does not build the manifest. You can use fallback_manifest to specify a map of the manifest that should be used if the expected one does not exist. However, a fallback was specifie.",
+					Detail:   "This may be because the build failed or it is on a branch that does not build the manifest. You can use fallback_manifest to specify a map of the manifest that should be used if the expected one does not exist. However, a fallback was specifie.",
 				})
 			}
 
@@ -275,7 +275,7 @@ func dataStileManifestRead(ctx context.Context, d *schema.ResourceData, m interf
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  fmt.Sprintf("Manifest %s not found for build %s in %s/%s", manifestName, bfpBuildNumber, org, pipeline),
-				Detail:   "This may be beause the build failed or it is on a branch that does not build the manifest. You can use fallback_manifest to specify a map of the manifest that should be used if the expected one does not exist.",
+				Detail:   "This may be because the build failed or it is on a branch that does not build the manifest. You can use fallback_manifest to specify a map of the manifest that should be used if the expected one does not exist.",
 			})
 			return diags
 		}


### PR DESCRIPTION
The error message required you to know how things work end-to-end. Instead,
break out the fetching and casting so that we can give a more specific error
message with actionable steps on how to fix it.

I also fixed up a couple of typos and lint issues.
