### PR TITLE
Add some retry to paper-over sporadic VPN connection issues.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module terraform-provider-hashicups
+module terraform-provider-stile
 
 go 1.14
 

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 
-	"terraform-provider-hashicups/stile"
+	"terraform-provider-stile/stile"
 )
 
 func main() {


### PR DESCRIPTION
When applying Terraform I regularly see failures to download the manifest. Add some retry to make it more reliable.